### PR TITLE
Correct solution to exercise

### DIFF
--- a/episodes/02-match-extract-strings.md
+++ b/episodes/02-match-extract-strings.md
@@ -85,7 +85,7 @@ Type the expression `[Cc]ommuni`. You get 16 matches. Why?
 
 ### Solution
 
-The word Community is present in the text with a capital `C` and with a lowercase `c` 16 times.
+The pattern `communi` with either a capital `C` or lowercase `c` is present in the text 16 times.
 
 :::::::::::::::::::::::::
 


### PR DESCRIPTION
In the exercise "Taking Capitalization into Consideration" the solution says that the word "community" is found in the text 16 times. This isn't correct, as some of these matches are to "communication", "communications", etc. This PR fixes the solution to match the exercise. 

<img width="764" alt="Screenshot 2023-10-16 at 12 45 32 PM" src="https://github.com/ErinBecker/lc-data-intro/assets/19176319/4ff9b080-a17b-4917-8f0f-ba7d081b40fb">
